### PR TITLE
Update test_validate.jl for new CodecZlib error type

### DIFF
--- a/test/test_validate.jl
+++ b/test/test_validate.jl
@@ -146,12 +146,12 @@ end
     zipsource(bad_uncompressed_file) do source
         # file is bad
         f = next_file(source)
-        @test_throws ErrorException validate(f)
+        @test_throws Exception validate(f)
     end
     zipsource(bad_uncompressed_file) do source
         # note: this error breaks reading because the zlib codec does not read complete information
         for file in source
-            @test_throws ErrorException read(file)
+            @test_throws Exception read(file)
         end
         # archive is bad
         @test_throws ErrorException validate(source)


### PR DESCRIPTION
https://github.com/JuliaIO/CodecZlib.jl/pull/93 adds a new error type for decompression errors. This PR updates some tests to be compatible with this change.